### PR TITLE
Use the existing method to clean up the context's memory.

### DIFF
--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -125,12 +125,13 @@ public:
     void SetHostname(const char * name) { mHostname = name; }
     const char * GetHostname() { return mHostname.c_str(); }
 
+    void Delete(GenericContext * context);
+
 private:
     MdnsContexts(){};
     static MdnsContexts sInstance;
     std::string mHostname;
 
-    void Delete(GenericContext * context);
     std::vector<GenericContext *> mContexts;
 };
 


### PR DESCRIPTION
This uses the existing memory cleanup method, although it's now made public.