### PR TITLE
cleanup operational ID extraction from certificates

### DIFF
--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -69,7 +69,7 @@ public:
 
     virtual bool IsActive() const { return true; }
 
-    virtual CHIP_ERROR SetPeerId(const Crypto::P256PublicKey & rootPublicKey, ByteSpan noc) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1707,17 +1707,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
             CommissioningStageComplete(err);
             return;
         }
-        Crypto::P256PublicKey rootPubKey;
-        Credentials::P256PublicKeySpan rootPubKeySpan;
-        err = Credentials::ExtractPublicKeyFromChipCert(params.GetRootCert().Value(), rootPubKeySpan);
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(Controller, "Error extracting public key from chip cert: %s", err.AsString());
-            CommissioningStageComplete(err);
-            return;
-        }
-        rootPubKey = Crypto::P256PublicKey(rootPubKeySpan); // deep copy
-        err        = proxy->SetPeerId(rootPubKey, params.GetNoc().Value());
+        err = proxy->SetPeerId(params.GetRootCert().Value(), params.GetNoc().Value());
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Error setting peer id: %s", err.AsString());

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -201,12 +201,11 @@ bool CommissioneeDeviceProxy::GetAddress(Inet::IPAddress & addr, uint16_t & port
 
 CommissioneeDeviceProxy::~CommissioneeDeviceProxy() {}
 
-CHIP_ERROR CommissioneeDeviceProxy::SetPeerId(const Crypto::P256PublicKey & rootPublicKey, ByteSpan noc)
+CHIP_ERROR CommissioneeDeviceProxy::SetPeerId(ByteSpan rcac, ByteSpan noc)
 {
     CompressedFabricId compressedFabricId;
     NodeId nodeId;
-    ReturnErrorOnFailure(
-        Credentials::ExtractNodeIdCompressedFabricIdFromRootPubKeyOpCert(rootPublicKey, noc, compressedFabricId, nodeId));
+    ReturnErrorOnFailure(Credentials::ExtractNodeIdCompressedFabricIdFromOpCerts(rcac, noc, compressedFabricId, nodeId));
     mPeerId = PeerId().SetCompressedFabricId(compressedFabricId).SetNodeId(nodeId);
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -212,7 +212,7 @@ public:
 
     NodeId GetDeviceId() const override { return mPeerId.GetNodeId(); }
     PeerId GetPeerId() const { return mPeerId; }
-    CHIP_ERROR SetPeerId(const Crypto::P256PublicKey & rootPublicKey, ByteSpan noc) override;
+    CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) override;
 
     bool MatchesSession(const SessionHandle & session) const { return mSecureSession.Contains(session); }
 

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -867,21 +867,23 @@ CHIP_ERROR ExtractNodeIdFabricIdFromOpCert(const ChipCertificateData & opcert, N
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ExtractNodeIdFabricIdCompressedFabricIdFromRootPubKeyOpCert(const Crypto::P256PublicKey & rootPubKey, ByteSpan noc,
-                                                                       CompressedFabricId & compressedFabricId, FabricId & fabricId,
-                                                                       NodeId & nodeId)
+CHIP_ERROR ExtractNodeIdFabricIdCompressedFabricIdFromOpCerts(ByteSpan rcac, ByteSpan noc, CompressedFabricId & compressedFabricId,
+                                                              FabricId & fabricId, NodeId & nodeId)
 {
+    Crypto::P256PublicKey rootPubKey;
+    Credentials::P256PublicKeySpan rootPubKeySpan;
+    ReturnErrorOnFailure(ExtractPublicKeyFromChipCert(rcac, rootPubKeySpan));
+    rootPubKey = Crypto::P256PublicKey(rootPubKeySpan);
     ReturnErrorOnFailure(Credentials::ExtractNodeIdFabricIdFromOpCert(noc, &nodeId, &fabricId));
     ReturnErrorOnFailure(GenerateCompressedFabricId(rootPubKey, fabricId, compressedFabricId));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ExtractNodeIdCompressedFabricIdFromRootPubKeyOpCert(const Crypto::P256PublicKey & rootPubKey, ByteSpan noc,
-                                                               CompressedFabricId & compressedFabricId, NodeId & nodeId)
+CHIP_ERROR ExtractNodeIdCompressedFabricIdFromOpCerts(ByteSpan rcac, ByteSpan noc, CompressedFabricId & compressedFabricId,
+                                                      NodeId & nodeId)
 {
     FabricId fabricId;
-    ReturnErrorOnFailure(
-        ExtractNodeIdFabricIdCompressedFabricIdFromRootPubKeyOpCert(rootPubKey, noc, compressedFabricId, fabricId, nodeId));
+    ReturnErrorOnFailure(ExtractNodeIdFabricIdCompressedFabricIdFromOpCerts(rcac, noc, compressedFabricId, fabricId, nodeId));
     return CHIP_NO_ERROR;
 }
 

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -800,22 +800,21 @@ CHIP_ERROR ExtractNodeIdFabricIdFromOpCert(const ChipCertificateData & opcert, N
 
 /**
  * Extract Node ID, Fabric ID and Compressed Fabric ID from an operational
- * certificate and root public key.
+ * certificate and its associated root certificate.
  *
  * @return CHIP_ERROR on failure or CHIP_NO_ERROR otherwise.
  */
-CHIP_ERROR ExtractNodeIdFabricIdCompressedFabricIdFromRootPubKeyOpCert(const Crypto::P256PublicKey & rootPubKey, ByteSpan noc,
-                                                                       CompressedFabricId & compressedFabricId, FabricId & fabricId,
-                                                                       NodeId & nodeId);
+CHIP_ERROR ExtractNodeIdFabricIdCompressedFabricIdFromOpCerts(ByteSpan rcac, ByteSpan noc, CompressedFabricId & compressedFabricId,
+                                                              FabricId & fabricId, NodeId & nodeId);
 
 /**
  * Extract Node ID and Compressed Fabric ID from an operational certificate
- * and root public key.
+ * and its associated root certificate.
  *
  * @return CHIP_ERROR on failure or CHIP_NO_ERROR otherwise.
  */
-CHIP_ERROR ExtractNodeIdCompressedFabricIdFromRootPubKeyOpCert(const Crypto::P256PublicKey & rootPubKey, ByteSpan noc,
-                                                               CompressedFabricId & compressedFabricId, NodeId & nodeId);
+CHIP_ERROR ExtractNodeIdCompressedFabricIdFromOpCerts(ByteSpan rcac, ByteSpan noc, CompressedFabricId & compressedFabricId,
+                                                      NodeId & nodeId);
 
 /**
  * Extract CASE Authenticated Tags from an operational certificate in ByteSpan TLV-encoded form.

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -1153,15 +1153,10 @@ static void TestChipCert_ExtractOperationalDiscoveryId(nlTestSuite * inSuite, vo
         NL_TEST_ASSERT(inSuite, nodeId == testCase.ExpectedNodeId);
         NL_TEST_ASSERT(inSuite, fabricId == testCase.ExpectedFabricId);
 
-        // Extract the Public key from the root certificate.
-        Credentials::P256PublicKeySpan rootPubKey;
-        err = Credentials::ExtractPublicKeyFromChipCert(rcac, rootPubKey);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-        // Extract Node ID and Fabric ID from the NOC, and generate the
-        // compressed fabric ID from the root CA public Key and fabric ID.
+        // Extract Node ID, Fabric ID and Compressed Fabric ID from the
+        // NOC and root certificate.
         CompressedFabricId compressedFabricId;
-        err = ExtractNodeIdFabricIdCompressedFabricIdFromRootPubKeyOpCert(rootPubKey, noc, compressedFabricId, fabricId, nodeId);
+        err = ExtractNodeIdFabricIdCompressedFabricIdFromOpCerts(rcac, noc, compressedFabricId, fabricId, nodeId);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, compressedFabricId == testCase.ExpectedCompressedFabricId);
         NL_TEST_ASSERT(inSuite, fabricId == testCase.ExpectedFabricId);


### PR DESCRIPTION
This amendment takes advantage #12915, which makes available
both the root certificate and NOC in memory at the same time
during commissioning.  Because of this, the commissioner no
longer needs to extract and store the Root CA public key to
generate the compressed fabric ID.